### PR TITLE
fix: #42 헤더 하단 배경 영역 레이아웃 개선

### DIFF
--- a/app/SharedPageLayout.tsx
+++ b/app/SharedPageLayout.tsx
@@ -16,6 +16,8 @@ export default function SharedPageLayout({
     <div className="layout-container">
       <div className="fixed-background"></div>
       <main className="content-wrapper">
+        <div style={{ height: "10vh", backgroundColor: "transparent", position: "sticky", top: 0, zIndex: 5 }}></div>
+        <div style={{ height: "10vh", backgroundColor: "transparent" }}></div>
         <div className="content-box">
           <h1 className="page-title">{title}</h1>
           {children}

--- a/app/shared-page-layout.css
+++ b/app/shared-page-layout.css
@@ -1,5 +1,5 @@
 .layout-container {
-  min-height: 100vh;
+  min-height: 100dvh;
   position: relative;
 }
 
@@ -8,7 +8,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   background-image: url('https://miro.medium.com/v2/resize:fit:2000/1*nf5RvOUHclJqEYIljcNmEw.jpeg');
   background-size: cover;
   background-position: center;
@@ -18,13 +18,11 @@
 .content-wrapper {
   position: relative;
   z-index: 1;
-  padding-top: 20%;
-  min-height: 100vh;
+  min-height: 100dvh;
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
 }
 
 .content-box {
@@ -33,11 +31,19 @@
   padding: 60px 40px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
   width: 100%;
-  min-height: 100dvh;
+  min-height: calc(100dvh - 10vh);
   font-weight: 600;
   color: #023047;
 }
 
 .page-title {
+  font-size: 1.5rem;
+  text-align: center;
   margin-bottom: 40px;
+}
+
+@media (min-width: 480px) {
+  .page-title {
+    text-align: start;
+  }
 }


### PR DESCRIPTION
- SharedPageLayout에 sticky 투명 블록 추가로 헤더 높이만큼 영역 보호

This closes #42 