### PR TITLE
refactor: #45 auth 관련 설정 변수들 config 파일 작성

### DIFF
--- a/app/components/AuthGuard.tsx
+++ b/app/components/AuthGuard.tsx
@@ -3,6 +3,7 @@
 import { useUserStore } from "@/app/stores/useUserStore";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { AUTH_CONFIG } from "@/config/auth";
 
 interface AuthGuardProps { children: React.ReactNode }
 
@@ -12,12 +13,6 @@ export default function AuthGuard({ children }: AuthGuardProps) {
   const pathname = usePathname();
   const [isHydrated, setIsHydrated] = useState(false);
 
-  // 로그인이 필요한 페이지들
-  const protectedPaths = ["/me", "/chatrooms"];
-
-  // 로그인한 사용자가 접근하면 안 되는 페이지들 (로그인/회원가입)
-  const authPaths = ["/signin", "/signup"];
-
   useEffect(() => {
     setIsHydrated(true);
   }, []);
@@ -26,10 +21,10 @@ export default function AuthGuard({ children }: AuthGuardProps) {
 
     if(!isHydrated) return;
 
-    const isProtectedPath = protectedPaths.some((path) =>
+    const isProtectedPath = AUTH_CONFIG.protectedPaths.some((path) =>
       pathname.startsWith(path)
     );
-    const isAuthPath = authPaths.some((path) => pathname.startsWith(path));
+    const isAuthPath = AUTH_CONFIG.authPaths.some((path) => pathname.startsWith(path));
     
     if (isProtectedPath && !user) {
       // 보호된 페이지인데 로그인하지 않은 경우

--- a/config/auth.ts
+++ b/config/auth.ts
@@ -1,0 +1,24 @@
+export const AUTH_CONFIG = {
+  // 인증이 필요하지 않은 공개 API 경로들
+  publicApiPaths: [
+    "/api/auth/signin",
+    "/api/users", // 회원가입
+    "/api/user/duplicate", // 중복 체크
+    "/api/weather", // 날씨 정보
+    "/api/translate", // 번역
+    "/api/cities", // 도시 정보
+  ],
+
+  // 로그인이 필요한 보호된 페이지 경로들
+  protectedPaths: [
+    "/me",
+    "/chatrooms",
+  ],
+
+  // 로그인한 사용자가 접근하면 안 되는 페이지들 (로그인/회원가입)
+  authPaths: [
+    "/signin", 
+    "/signup",
+  ],
+
+} as const;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAccessToken } from "@/utils/auth/tokenUtils";
+import { AUTH_CONFIG } from "@/config/auth";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // API 경로에 대해서만 토큰 검증
   if (pathname.startsWith("/api")) {
-    // 인증이 필요하지 않은 API 경로들
-    const publicApiPaths = [
-      "/api/auth/signin",
-      "/api/users", // 회원가입
-      "/api/user/duplicate", // 중복 체크
-      "/api/weather", // 날씨 정보
-      "/api/translate", // 번역
-    ];
 
     // 공개 API 경로는 통과
-    if (publicApiPaths.some((path) => pathname.startsWith(path))) {
+    if (AUTH_CONFIG.publicApiPaths.some((path) => pathname.startsWith(path))) {
       return NextResponse.next();
     }
 


### PR DESCRIPTION
- 보호된 페이지 경로
- 인증이 필요하지 않은 공개 api 경로
- 로그인 사용자가 접근하면 안되는 페이지들 `AUTH_CONFIG` 상수에 저장
- 관련 파일들 import 적용