### PR TITLE
Feat: #88 채팅방 UI 리디자인 및 메시지 렌더링 최적화

### DIFF
--- a/app/(anon)/chatrooms/[id]/components/ChatInput.module.css
+++ b/app/(anon)/chatrooms/[id]/components/ChatInput.module.css
@@ -1,0 +1,36 @@
+.inputWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 40vw;
+  margin: 2vw auto 0;
+}
+
+.inputArea {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.textarea {
+  width: 100%;
+  padding: 12px 40px 12px 12px;
+  font-size: 1rem;
+  resize: none;
+  height: 56px;
+  border-radius: 24px;
+  border: 1px solid #ccc;
+  outline: none;
+  background-color: white;
+}
+
+.sendButton {
+  position: absolute;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: gray;
+}
+

--- a/app/(anon)/chatrooms/[id]/components/ChatInput.tsx
+++ b/app/(anon)/chatrooms/[id]/components/ChatInput.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, KeyboardEvent } from "react";
 import { parseTags } from "./ParseTags";
 import { ChatReply } from "./ChatReply";
 import { ChatInputProps } from "../types";
+import styles from "./ChatInput.module.css";
 
 export default function ChatInput({
   onSend,
@@ -11,21 +12,17 @@ export default function ChatInput({
   onCancelReply,
 }: ChatInputProps) {
   const [input, setInput] = useState("");
-  const [isComposing, setIsComposing] = useState(false); // 한글 입력 상태
+  const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleSend = () => {
     if (!input.trim()) return;
-
     const tags = parseTags(input);
     onSend(input, tags, replyTo);
     setInput("");
-    if (replyTo) {
-      onCancelReply(); // 답글 보낸 후 초기화
-    }
-
+    if (replyTo) onCancelReply();
     setTimeout(() => {
-      textareaRef.current?.scrollIntoView({ behavior: "smooth" }); // 최근 채팅으로 스크롤 이동
+      textareaRef.current?.scrollIntoView({ behavior: "smooth" });
     }, 0);
   };
 
@@ -37,31 +34,23 @@ export default function ChatInput({
   };
 
   return (
-    <div
-      style={{ display: "flex", flexDirection: "column", marginTop: "1rem" }}
-    >
+    <div className={styles.inputWrapper}>
       {replyTo && <ChatReply msg={replyTo} onCancel={onCancelReply} />}
-      <textarea
-        ref={textareaRef}
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onCompositionStart={() => setIsComposing(true)} // 한글 입력 시작
-        onCompositionEnd={() => setIsComposing(false)} //한글 입력 종료
-        placeholder="메시지를 입력하세요 (Enter: 전송, Shift+Enter: 줄바꿈)"
-        style={{
-          padding: "8px",
-          resize: "none",
-          height: "80px",
-          fontSize: "1rem",
-        }}
-      />
-      <button
-        onClick={handleSend}
-        style={{ marginTop: "8px", alignSelf: "flex-end" }}
-      >
-        전송
-      </button>
+      <div className={styles.inputArea}>
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          placeholder="메시지를 입력하세요"
+          className={styles.textarea}
+        />
+        <button onClick={handleSend} className={styles.sendButton}>
+          ➤
+        </button>
+      </div>
     </div>
   );
 }

--- a/app/(anon)/chatrooms/[id]/components/ChatLog.module.css
+++ b/app/(anon)/chatrooms/[id]/components/ChatLog.module.css
@@ -1,8 +1,7 @@
 .chatContainer {
   flex-grow: 1;
   overflow-y: auto;
-  padding: 0 4px;
-  min-height: 0;
+  padding: 0 1%;
 }
 
 .messageItem {
@@ -15,6 +14,7 @@
 .sender {
   font-weight: 300;
   color: #939393;
+  font-size: 0.65rem;
 }
 
 .replyBox {
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: row;
   max-width: 100%;
-  margin: 12px 0;
+  margin-bottom: 12px;
 }
 
 .myWrapper {
@@ -43,7 +43,7 @@
 }
 
 .myTranslateWrap {
-  align-self: flex-start;
+  align-self: flex-end;
   margin-bottom: 4px;
 }
 
@@ -81,7 +81,7 @@
   border-radius: 18px 3px 18px 18px; /* 말풍선 모양 */
   max-width: 90%;
   margin: 6px 0;
-  font-size: 15px;
+  font-size: 0.85rem;
   line-height: 1.4;
 }
 
@@ -94,15 +94,21 @@
   border-radius: 3px 18px 18px 18px;
   max-width: 80%;
   margin: 6px 0;
-  font-size: 15px;
+  font-size: 0.85rem;
   line-height: 1.4;
 }
 
-.timestamp {
-  /* margin-left: 6px; */
-  font-size: 12px;
+.mytimestamp {
+  font-size: 10px;
+  color: #ffffff;
+  align-self: flex-end;
+  font-size: 0.6rem;
+}
+.othertimestamp {
+  font-size: 10px;
   color: #888;
   align-self: flex-end;
+  font-size: 0.6rem;
 }
 
 .translateButton {
@@ -112,5 +118,17 @@
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.highlighted {
+  background-color: #fff9d1;
+  border-left: 4px solid #ffd700;
+  padding-left: 8px;
+}
+.searchNav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 8px;
 }
 

--- a/app/(anon)/chatrooms/[id]/components/ChatLog.tsx
+++ b/app/(anon)/chatrooms/[id]/components/ChatLog.tsx
@@ -11,8 +11,17 @@ export default function ChatLog({
   messages: incomingMessages,
   onReply,
   currentUserId,
-}: ChatLogProps) {
+  searchResultIds = [],
+  currentIndex = 0,
+  onNavigateSearchResult,
+}: ChatLogProps & {
+  searchResultIds?: number[];
+  currentIndex?: number;
+  onNavigateSearchResult?: (direction: "prev" | "next") => void;
+}) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const messageRefs = useRef<Map<number, HTMLLIElement | null>>(new Map());
+  const highlightSet = new Set(searchResultIds);
   const [renderedMessages, setRenderedMessages] = useState(incomingMessages);
   const [translated, setTranslated] = useState<Record<number, string>>({});
   const [isTranslated, setIsTranslated] = useState<Record<number, boolean>>({});
@@ -22,9 +31,12 @@ export default function ChatLog({
     if (incomingMessages.length > renderedMessages.length) {
       const newMessages = incomingMessages.slice(renderedMessages.length);
       setRenderedMessages((prev) => [...prev, ...newMessages]);
-      console.log("newMessages", newMessages);
     }
   }, [incomingMessages]);
+
+  useEffect(() => {
+    setRenderedMessages(incomingMessages);
+  }, [searchResultIds, incomingMessages]);
 
   // ✅ 새 메시지 추가 시 맨 아래로 스크롤
   useEffect(() => {
@@ -48,110 +60,126 @@ export default function ChatLog({
       setIsTranslated((prev) => ({ ...prev, [index]: true }));
     }
   };
+  // ✅ 검색 결과로 스크롤 이동
+  useEffect(() => {
+    const targetId = Number(searchResultIds[currentIndex]);
+    console.log("search결과", searchResultIds);
+    console.log("✅ currentIndex:", currentIndex);
+    console.log("✅ targetId to scroll:", targetId);
+    console.log("✅ all ref keys:", Array.from(messageRefs.current.keys()));
+    setTimeout(() => {
+      const targetElement = messageRefs.current.get(targetId);
+      if (targetElement) {
+        targetElement.scrollIntoView({ behavior: "smooth", block: "center" });
+      } else {
+        console.warn("❌ ref 없음:", targetId);
+      }
+    }, 0); // 0ms 딜레이로 다음 이벤트 루프에서 실행
+  }, [currentIndex, searchResultIds]);
 
   return (
-    <ul className={styles.chatContainer}>
-      {renderedMessages.map((msg, i) => {
-        const isMe = msg.senderId === currentUserId;
-        const formattedTime = msg.sentAt
-          ? format(new Date(msg.sentAt), "a h:mm", { locale: ko })
-          : "";
+    <>
+      <ul className={styles.chatContainer}>
+        {renderedMessages.map((msg, i) => {
+          const isMe = msg.senderId === currentUserId;
+          const isHighlighted = highlightSet.has(msg.id!);
+          const formattedTime = msg.sentAt
+            ? format(new Date(msg.sentAt), "a h:mm", { locale: ko })
+            : "";
+          const repliedTo = msg.replyToId
+            ? renderedMessages.find((m) => m.id === msg.replyToId)
+            : null;
 
-        const repliedTo = msg.replyToId
-          ? renderedMessages.find((m) => m.id === msg.replyToId)
-          : null;
-
-        return (
-          <li key={msg.id} className={styles.messageItem}>
-            <span className={styles.sender}>
-              {isMe ? "" : msg.senderNickname}
-            </span>
-
-            {repliedTo && (
-              <div className={styles.replyBox}>
-                <div>↪ {repliedTo.senderNickname}</div>
-                <div>{repliedTo.content}</div>
-              </div>
-            )}
-
-            {/* <span
-              className={`${styles.messageContent} ${
-                isMe ? styles.myMessage : styles.otherMessage
-              }`}
-            >
-              <span
-                onClick={() => onReply(msg)}
-                dangerouslySetInnerHTML={{
-                  __html: highlightTags(
-                    isTranslated[i] && translated[i]
-                      ? translated[i]
-                      : msg.content
-                  ),
-                }}
-              />
-              <span className={styles.timestamp}>{formattedTime}</span>
-
-              <button
-                onClick={() => handleTranslateToggle(i, msg.content)}
-                className={styles.translateButton}
-              >
-                {isTranslated[i] ? "Original" : "Translate"}
-              </button>
-            </span> */}
-            <div
+          return (
+            <li
               key={msg.id}
-              className={`${styles.messageWrapper} ${
-                isMe ? styles.myWrapper : styles.otherWrapper
+              ref={(el) => {
+                if (msg.id != null && el) {
+                  const numericId = Number(msg.id);
+                  console.log("✅ ref 등록됨:", numericId);
+                  messageRefs.current.set(numericId, el);
+                }
+              }}
+              className={`${styles.messageItem} ${
+                isHighlighted ? styles.highlighted : ""
               }`}
             >
-              {/* ✅ 내 메시지 → 버튼 위쪽 왼쪽에 */}
-              {isMe && (
-                <div className={styles.myTranslateWrap}>
-                  <button
-                    onClick={() => handleTranslateToggle(i, msg.content)}
-                    className={styles.translateButton}
-                  >
-                    {isTranslated[i] ? "Original" : "Translate"}
-                  </button>
-                </div>
-              )}
-
-              {/* 💬 말풍선 */}
-              <span
-                className={`${styles.messageContent} ${
-                  isMe ? styles.myMessage : styles.otherMessage
-                }`}
-              >
-                <span
-                  onClick={() => onReply(msg)}
-                  dangerouslySetInnerHTML={{
-                    __html: highlightTags(
-                      isTranslated[i] && translated[i]
-                        ? translated[i]
-                        : msg.content
-                    ),
-                  }}
-                />
-                <span className={styles.timestamp}>{formattedTime}</span>
+              <span className={styles.sender}>
+                {isMe ? "" : msg.senderNickname}
               </span>
 
-              {/* ✅ 상대 메시지 → 버튼 아래쪽 오른쪽에 */}
-              {!isMe && (
-                <div className={styles.otherTranslateWrap}>
-                  <button
-                    onClick={() => handleTranslateToggle(i, msg.content)}
-                    className={styles.translateButton}
-                  >
-                    {isTranslated[i] ? "Original" : "Translate"}
-                  </button>
+              {repliedTo && (
+                <div className={styles.replyBox}>
+                  <div>↪ {repliedTo.senderNickname}</div>
+                  <div>{repliedTo.content}</div>
                 </div>
               )}
-            </div>
-          </li>
-        );
-      })}
-      <div ref={bottomRef} />
-    </ul>
+
+              <div
+                className={`${styles.messageWrapper} ${
+                  isMe ? styles.myWrapper : styles.otherWrapper
+                }`}
+              >
+                {isMe && (
+                  <div className={styles.myTranslateWrap}>
+                    <button
+                      onClick={() => handleTranslateToggle(i, msg.content)}
+                      className={styles.translateButton}
+                    >
+                      {isTranslated[i] ? "Original" : "Translate"}
+                    </button>
+                  </div>
+                )}
+                <span
+                  className={`${styles.messageContent} ${
+                    isMe ? styles.myMessage : styles.otherMessage
+                  }`}
+                >
+                  <span
+                    onClick={() => onReply(msg)}
+                    dangerouslySetInnerHTML={{
+                      __html: highlightTags(
+                        isTranslated[i] && translated[i]
+                          ? translated[i]
+                          : msg.content
+                      ),
+                    }}
+                  />
+                  <span
+                    className={`${
+                      isMe ? styles.mytimestamp : styles.othertimestamp
+                    }`}
+                  >
+                    {formattedTime}
+                  </span>
+                </span>
+                {!isMe && (
+                  <div className={styles.otherTranslateWrap}>
+                    <button
+                      onClick={() => handleTranslateToggle(i, msg.content)}
+                      className={styles.translateButton}
+                    >
+                      {isTranslated[i] ? "Original" : "Translate"}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+        <div ref={bottomRef} />
+      </ul>
+
+      {searchResultIds.length > 0 && (
+        <div className={styles.searchNav}>
+          <button onClick={() => onNavigateSearchResult?.("prev")}>◀</button>
+          <span>
+            {currentIndex + 1} / {searchResultIds.length}
+          </span>
+          <button onClick={() => onNavigateSearchResult?.("next")}>▶</button>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/app/(anon)/chatrooms/[id]/components/ChatSearch.module.css
+++ b/app/(anon)/chatrooms/[id]/components/ChatSearch.module.css
@@ -1,0 +1,58 @@
+.container {
+  /* padding: 1rem; */
+  max-width: 36rem;
+  /* margin: 0 auto; */
+  margin-left: 24px;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.inputGroup {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.input {
+  border: 1px solid #ccc;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  flex: 1;
+}
+
+.button {
+  background-color: #3b82f6;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  border: none;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: #2563eb;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resultItem {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.resultDate {
+  font-size: 0.875rem;
+  color: #4b5563;
+  margin-bottom: 0.25rem;
+}
+

--- a/app/(anon)/chatrooms/[id]/page.module.css
+++ b/app/(anon)/chatrooms/[id]/page.module.css
@@ -1,23 +1,37 @@
+.wrapper {
+  position: relative;
+  /* height: 100vh; */
+  overflow: hidden;
+  width: 1280px;
+  margin: 0 auto;
+  padding-top: 10vh;
+}
+.searchBox {
+  position: absolute;
+  z-index: 10;
+}
 .chatRoomContainer {
-  width: 50vw;
-  margin: 100px auto 0 auto; /* 상단 여백 + 중앙 정렬 */
+  position: relative;
+  width: 40vw;
+  margin: 0 auto;
   padding: 24px;
   background-color: #ffffff;
   border-radius: 12px;
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
-  min-height: 80vh;
+  height: 70vh;
 }
 
 .chatSection {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  min-height: 0; 
-  max-height: 70vh; 
+  min-height: 0;
+  max-height: 70vh;
 }
 
 .chatInputWrapper {
   margin-top: auto;
 }
+

--- a/app/(anon)/chatrooms/[id]/page.tsx
+++ b/app/(anon)/chatrooms/[id]/page.tsx
@@ -17,17 +17,19 @@ export default function ChatRoom() {
   const [replyTo, setReplyTo] = useState<Message | null>(null);
   const socketRef = useRef<Socket | null>(null);
   const user = useUserStore((state) => state.user);
+  const [searchResultIds, setSearchResultIds] = useState<number[]>([]);
+  const [currentSearchIndex, setCurrentSearchIndex] = useState(0);
 
   // ✅ 기존 채팅 불러오기 (로그 초기 로딩)
   useEffect(() => {
     const fetchInitialMessages = async () => {
-      const res = await fetch(`/api/chat/logs?roomId=${roomId}&days=7`, {
+      const res = await fetch(`/api/chat/logs?roomId=${roomId}&days=30`, {
         method: "GET",
         credentials: "include",
       });
       const data: Message[] = await res.json();
       setMessages(data);
-      console.log("data",data);
+      console.log("data", data);
     };
 
     fetchInitialMessages();
@@ -65,32 +67,50 @@ export default function ChatRoom() {
       sender: user?.nickname ?? "",
       senderId: user?.id,
       replyToId: replyTo?.id ?? null,
-      sentAt : new Date().toISOString(),
+      sentAt: new Date().toISOString(),
     };
     socketRef.current?.emit("sendMessage", message);
     console.log(message);
   };
 
   return (
-    <div>
-      <ChatSearch />
+    <div className={styles.wrapper}>
+      <div className={styles.searchBox}>
+        <ChatSearch
+          onSearchResults={(ids) => {
+            setSearchResultIds(ids);
+            setCurrentSearchIndex(0);
+          }}
+        />
+      </div>
       <div className={styles.chatRoomContainer}>
-        
         <div className={styles.chatSection}>
           <ChatLog
             messages={messages}
             onReply={setReplyTo}
             currentUserId={user?.id ?? null}
+            searchResultIds={searchResultIds}
+            currentIndex={currentSearchIndex}
+            onNavigateSearchResult={(direction) => {
+              setCurrentSearchIndex((prev) => {
+                if (direction === "prev") {
+                  return prev === 0 ? searchResultIds.length - 1 : prev - 1;
+                } else {
+                  return prev === searchResultIds.length - 1 ? 0 : prev + 1;
+                }
+              });
+            }}
           />
-          <div className={styles.chatInputWrapper}>
-            <ChatInput
-              onSend={handleSend}
-              replyTo={replyTo}
-              onCancelReply={() => setReplyTo(null)}
-            />
-          </div>
         </div>
+      </div>
+      <div className={styles.chatInputWrapper}>
+        <ChatInput
+          onSend={handleSend}
+          replyTo={replyTo}
+          onCancelReply={() => setReplyTo(null)}
+        />
       </div>
     </div>
   );
 }
+

--- a/app/api/chat/logs/route.ts
+++ b/app/api/chat/logs/route.ts
@@ -25,15 +25,20 @@ export async function GET(req: NextRequest) {
     );
   }
 
-
   try {
     const supabase = await createClient();
     console.log("supabase", supabase);
-    const useCase = new GetRecentChatsUseCase(new SbChatLogRepository(supabase));
+    const useCase = new GetRecentChatsUseCase(
+      new SbChatLogRepository(supabase)
+    );
     const messages = await useCase.execute({ chatRoomId, days: dayCount });
     return NextResponse.json(messages);
   } catch (error) {
     console.error("❌ Error in /api/chats/logs:", error);
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
   }
 }
+

--- a/app/api/chat/search/route.ts
+++ b/app/api/chat/search/route.ts
@@ -21,12 +21,15 @@ export async function GET(req: NextRequest) {
   );
 
   try {
-    const chatRoomId = parseInt(roomId, 10);// 문자열을 정수로 변환s
+    const chatRoomId = parseInt(roomId, 10); // 문자열을 정수로 변환s
     const result = await useCase.execute({ chat: keyword, chatRoomId });
     return NextResponse.json(result);
   } catch (error) {
     console.error("❌ Error in /api/chats/search:", error);
-    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
   }
 }
 


### PR DESCRIPTION
## 주요 변경 사항 ✨

- 채팅 메시지 전체 렌더링에서 신규 메시지만 렌더링하도록 최적화
- 사용자 본인이 보낸 메시지에도 `sentAt` 시간 정상 표출되도록 수정
- 말풍선 스타일을 iOS 스타일로 리디자인
- `Translate` 버튼을 말풍선 외부에 위치시켜 가독성 개선
  - 내 메시지일 경우: 왼쪽 상단
  - 상대 메시지일 경우: 오른쪽 하단
- Header 영역을 width 1280px로 중앙 상단 고정 처리
- 채팅방에서는 `Footer`가 보이지 않도록 layout 조건 분기 추가

## 관련 이슈 📌
Closes #88 
